### PR TITLE
Fix property management image path

### DIFF
--- a/components/PropertyManagementSection.tsx
+++ b/components/PropertyManagementSection.tsx
@@ -32,7 +32,7 @@ export default function PropertyManagementSection() {
       {/* Background Image */}
       <div className="absolute inset-0">
         <Image
-          src="/images/Properties/LexingtonNight/WellcomeDrs.png"
+          src="/images/properties/LexingtonNight/WellcomeDrs.png"
           alt="Welcome doctors - property management background"
           fill
           className="object-cover"


### PR DESCRIPTION
## Summary
- correct WellcomeDrs image path in PropertyManagementSection

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run build`
- `npm run start` & `curl -I http://localhost:3000/images/properties/LexingtonNight/WellcomeDrs.png`


------
https://chatgpt.com/codex/tasks/task_e_688f03729b208324883cb480edbb01ca