### PR TITLE
feat: display host avatar when available

### DIFF
--- a/app/property/[id]/components/PropertyInfo.tsx
+++ b/app/property/[id]/components/PropertyInfo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Star } from 'lucide-react';
+import Image from 'next/image';
 
 interface PropertyInfoProps {
   property: {
@@ -23,6 +24,7 @@ interface PropertyInfoProps {
     }>;
     host: {
       name: string;
+      avatar?: string;
     };
   };
 }
@@ -65,11 +67,21 @@ export default function PropertyInfo({ property }: PropertyInfoProps) {
             <span>{property.sqft} sqft</span>
           </div>
         </div>
-        <div className="w-12 h-12 bg-gray-300 rounded-full flex items-center justify-center">
-          <span className="text-lg font-semibold text-gray-700">
-            {property.host.name.charAt(0)}
-          </span>
-        </div>
+        {property.host.avatar ? (
+          <Image
+            src={property.host.avatar}
+            alt={property.host.name}
+            width={48}
+            height={48}
+            className="w-12 h-12 rounded-full object-cover"
+          />
+        ) : (
+          <div className="w-12 h-12 bg-gray-300 rounded-full flex items-center justify-center">
+            <span className="text-lg font-semibold text-gray-700">
+              {property.host.name.charAt(0)}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Property Description */}


### PR DESCRIPTION
## Summary
- show property host avatar using Next.js Image when provided
- fall back to host's initial when avatar is missing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_689226130f248324a83669bfd51cdf4c