### PR TITLE
Add host profiles to property data

### DIFF
--- a/app/property/[id]/components/PropertyInfo.tsx
+++ b/app/property/[id]/components/PropertyInfo.tsx
@@ -23,6 +23,10 @@ interface PropertyInfoProps {
     }>;
     host: {
       name: string;
+      avatar?: string;
+      joinedYear?: string;
+      reviewCount?: number;
+      rating?: number;
     };
   };
 }

--- a/app/property/[id]/page.tsx
+++ b/app/property/[id]/page.tsx
@@ -89,16 +89,18 @@ export default function PropertyDetails({ params }: PropertyDetailsProps) {
 
   // Property data matching the property cards
   const property = PROPERTY_DATA[params.id as keyof typeof PROPERTY_DATA] || PROPERTY_DATA['1'];
-  
+
+  const defaultHost = {
+    name: "Sarah",
+    avatar: "/images/host-avatar.jpg",
+    joinedYear: "2019",
+    reviewCount: 89,
+    rating: 4.8
+  };
+
   const propertyWithDefaults = {
     ...property,
-    host: {
-      name: "Sarah",
-      avatar: "/images/host-avatar.jpg",
-      joinedYear: "2019",
-      reviewCount: 89,
-      rating: 4.8
-    },
+    host: property.host || defaultHost,
     images: PROPERTY_DETAIL_IMAGES,
     amenities: [
       { icon: Wifi, label: "Free WiFi" },

--- a/lib/data/properties.ts
+++ b/lib/data/properties.ts
@@ -13,7 +13,14 @@ export const PROPERTY_DATA = {
     proximityBadges: [
       { text: "14 min drive to Our Lady of the Lake Hospital", bgColor: "bg-blue-100", textColor: "text-blue-800" },
       { text: "16 min drive to BR General Hospital", bgColor: "bg-green-100", textColor: "text-green-800" }
-    ]
+    ],
+    host: {
+      name: "Agnes Andrews",
+      avatar: "/images/team/agnes-andrews.jpg",
+      joinedYear: "2020",
+      reviewCount: 127,
+      rating: 4.9
+    }
   },
   '2': {
     id: '2',
@@ -29,7 +36,14 @@ export const PROPERTY_DATA = {
     proximityBadges: [
       { text: "10 min drive to Our Lady of the Lake Hospital", bgColor: "bg-blue-100", textColor: "text-blue-800" },
       { text: "4 min drive to BR General Hospital - Mid City", bgColor: "bg-green-100", textColor: "text-green-800" }
-    ]
+    ],
+    host: {
+      name: "Agnes Andrews",
+      avatar: "/images/team/agnes-andrews.jpg",
+      joinedYear: "2020",
+      reviewCount: 89,
+      rating: 4.8
+    }
   },
   '3': {
     id: '3',
@@ -45,7 +59,14 @@ export const PROPERTY_DATA = {
     proximityBadges: [
       { text: "7 min drive to Our Lady of the Lake Hospital", bgColor: "bg-blue-100", textColor: "text-blue-800" },
       { text: "20 min drive to BR General Hospital", bgColor: "bg-green-100", textColor: "text-green-800" }
-    ]
+    ],
+    host: {
+      name: "Nayo Andrews",
+      avatar: "/images/team/nayo-andrews.jpg",
+      joinedYear: "2021",
+      reviewCount: 156,
+      rating: 4.7
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- add detailed host info for sample properties
- load property-specific hosts or fall back to default host
- extend host type definition for optional profile fields

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68922524bf808324aa1118d79d962976