### PR TITLE
feat: display host avatar and details

### DIFF
--- a/app/property/[id]/components/PropertyInfo.tsx
+++ b/app/property/[id]/components/PropertyInfo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Star } from 'lucide-react';
+import Image from 'next/image';
 
 interface PropertyInfoProps {
   property: {
@@ -61,6 +62,18 @@ export default function PropertyInfo({ property }: PropertyInfoProps) {
           <h2 className="text-xl font-semibold text-gray-900">
             Hosted by {property.host.name}
           </h2>
+          {property.host.rating !== undefined && (
+            <div className="flex items-center text-sm text-gray-600 mt-1 space-x-1">
+              <Star className="w-4 h-4 text-yellow-400 fill-current" />
+              <span className="font-medium">{property.host.rating}</span>
+              {property.host.reviewCount !== undefined && (
+                <span>({property.host.reviewCount} reviews)</span>
+              )}
+              {property.host.joinedYear && (
+                <span>• Joined in {property.host.joinedYear}</span>
+              )}
+            </div>
+          )}
           <div className="flex items-center space-x-2 text-gray-600 mt-1">
             <span>{property.bedrooms} bedrooms</span>
             <span>•</span>
@@ -69,11 +82,21 @@ export default function PropertyInfo({ property }: PropertyInfoProps) {
             <span>{property.sqft} sqft</span>
           </div>
         </div>
-        <div className="w-12 h-12 bg-gray-300 rounded-full flex items-center justify-center">
-          <span className="text-lg font-semibold text-gray-700">
-            {property.host.name.charAt(0)}
-          </span>
-        </div>
+        {property.host.avatar ? (
+          <Image
+            src={property.host.avatar}
+            alt={property.host.name}
+            width={48}
+            height={48}
+            className="w-12 h-12 rounded-full object-cover"
+          />
+        ) : (
+          <div className="w-12 h-12 bg-gray-300 rounded-full flex items-center justify-center">
+            <span className="text-lg font-semibold text-gray-700">
+              {property.host.name.charAt(0)}
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Property Description */}


### PR DESCRIPTION
## Summary
- show host avatar when available with fallback initial
- display host rating, review count, and joined year in property info

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires initial configuration)


------
https://chatgpt.com/codex/tasks/task_e_68922e4237a883248e6c82ab73107b49