### PR TITLE
Style host introduction on property details

### DIFF
--- a/app/property/[id]/components/PropertyInfo.tsx
+++ b/app/property/[id]/components/PropertyInfo.tsx
@@ -59,8 +59,9 @@ export default function PropertyInfo({ property }: PropertyInfoProps) {
       {/* Host Information */}
       <div className="flex items-center justify-between pb-6 border-b border-gray-200">
         <div>
-          <h2 className="text-xl font-semibold text-gray-900">
-            Hosted by {property.host.name}
+          <h2 className="text-xl">
+            <span className="text-[#888]">Hosted by</span>{' '}
+            <span className="text-black font-semibold">{property.host.name}</span>
           </h2>
           {property.host.rating !== undefined && (
             <div className="flex items-center text-sm text-gray-600 mt-1 space-x-1">


### PR DESCRIPTION
## Summary
- differentiate host introduction text and host name colors for clearer visual hierarchy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6892947ccf0c83249ffb557d7ea108df