### PR TITLE
Add Google One Tap authentication component

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,3 +14,4 @@ NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
 # OAuth Provider Configuration (optional)
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import { Inter } from 'next/font/google'
+import GoogleOneTap from '@/components/GoogleOneTap'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -15,7 +16,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <GoogleOneTap />
+        {children}
+      </body>
     </html>
   )
 }

--- a/components/GoogleOneTap.tsx
+++ b/components/GoogleOneTap.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+import { createClient } from '@/lib/supabase/client'
+
+export default function GoogleOneTap() {
+  useEffect(() => {
+    const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID
+    if (!clientId) return
+
+    const script = document.createElement('script')
+    script.src = 'https://accounts.google.com/gsi/client'
+    script.async = true
+    script.onload = () => {
+      ;(window as any).google?.accounts.id.initialize({
+        client_id: clientId,
+        callback: async ({ credential }: { credential?: string }) => {
+          if (!credential) return
+          const supabase = createClient()
+          await supabase.auth.signInWithIdToken({
+            provider: 'google',
+            token: credential,
+          })
+        },
+      })
+      ;(window as any).google?.accounts.id.prompt()
+    }
+    document.head.appendChild(script)
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- add `GoogleOneTap` client component that loads Google Identity Services and signs in via Supabase
- mount the component in the root layout so One Tap runs on every page
- document `NEXT_PUBLIC_GOOGLE_CLIENT_ID` in `.env.local.example`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6892c70df1b88324bafc47d7e507315d