### PR TITLE
Remove Acadian property and enlarge remaining cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
           </div>
           
           {/* Property Cards Grid - Mobile Optimized */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 lg:gap-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6 lg:gap-8">
             {Object.entries(PROPERTY_DATA).map(([id, property]) => (
               <PropertyCard
                 key={id}

--- a/app/property/[id]/page.tsx
+++ b/app/property/[id]/page.tsx
@@ -24,6 +24,7 @@ import PropertyGallery from './components/PropertyGallery';
 import PropertyInfo from './components/PropertyInfo';
 import ReviewsSection from './components/ReviewsSection';
 import { PROPERTY_DATA, PROPERTY_DETAIL_IMAGES } from '@/lib/data/properties';
+import { notFound } from 'next/navigation';
 
 const DEFAULT_HOST = {
   name: 'Sarah',
@@ -106,8 +107,10 @@ export default function PropertyDetails({ params }: PropertyDetailsProps) {
   const nights = calculateNights();
 
   // Property data matching the property cards
-  const property =
-    PROPERTY_DATA[params.id as keyof typeof PROPERTY_DATA] || PROPERTY_DATA['1'];
+  const property = PROPERTY_DATA[params.id as keyof typeof PROPERTY_DATA];
+  if (!property) {
+    notFound();
+  }
 
   const host =
     'host' in property && property.host ? property.host : DEFAULT_HOST;

--- a/components/PropertyCard.tsx
+++ b/components/PropertyCard.tsx
@@ -44,7 +44,7 @@ export default function PropertyCard({
       href={`/property/${id}`} 
       className="block bg-white rounded-3xl shadow-xl overflow-hidden hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-2 cursor-pointer"
     >
-      <div className="h-80 relative overflow-hidden">
+      <div className="h-96 relative overflow-hidden">
         <Image
           src={imageUrl}
           alt={imageAlt}

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -111,7 +111,6 @@ export default function SearchBar({
 
   const locations = [
     { name: 'Concord Estates', address: '2978 Lexington Dr, Baton Rouge, LA 70808', propertyId: '3' },
-    { name: 'N Acadian Thruway', address: '214 S Acadian Thruway, Baton Rouge, LA 70806', propertyId: '2' },
     { name: 'Maryrose Place', address: '995 N Leighton Dr, Baton Rouge, LA 70806', propertyId: '1' }
   ];
 

--- a/lib/data/properties.ts
+++ b/lib/data/properties.ts
@@ -22,29 +22,6 @@ export const PROPERTY_DATA = {
       rating: 4.9
     }
   },
-  '2': {
-    id: '2',
-    title: "214 S Acadian Thruway, Baton Rouge, LA 70806",
-    location: "Acadian Village, Baton Rouge, LA",
-    rating: 4.8,
-    reviewCount: 89,
-    price: 149,
-    description: "Luxury accommodation for doctors with proximity to mid-city night-life, walkable distance to BR General and schools.",
-    bedrooms: 3,
-    bathrooms: 2,
-    sqft: 1736,
-    proximityBadges: [
-      { text: "10 min drive to Our Lady of the Lake Hospital", bgColor: "bg-blue-100", textColor: "text-blue-800" },
-      { text: "4 min drive to BR General Hospital - Mid City", bgColor: "bg-green-100", textColor: "text-green-800" }
-    ],
-    host: {
-      name: "Agnes Andrews",
-      avatar: "/images/team/agnes-andrews.jpg",
-      joinedYear: "2020",
-      reviewCount: 89,
-      rating: 4.8
-    }
-  },
   '3': {
     id: '3',
     title: "2978 Lexington Dr, Baton Rouge, LA 70808",
@@ -72,7 +49,6 @@ export const PROPERTY_DATA = {
 
 export const PROPERTY_IMAGES = {
   '1': "/images/properties/Leighton/dining-chats.jpg",
-  '2': "/images/properties/Leighton/kitchen-chats.jpg", 
   '3': "/images/properties/Leighton/living-room-chats.jpg"
 };
 


### PR DESCRIPTION
## Summary
- remove 214 S Acadian Thruway property and related assets
- expand remaining property cards and tweak layout for two-card grid
- add 404 handling for unknown property ids

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893a07caddc83249dd7d6fa1ab49b50