### PR TITLE
Host portal: publish guard requires cover; MediaManager Cover badge

### DIFF
--- a/app/portal/host/page.tsx
+++ b/app/portal/host/page.tsx
@@ -20,6 +20,7 @@ export default function HostPortalPage() {
   const supabase = useMemo(() => createClient(), []);
   const [hasMapLink, setHasMapLink] = useState(false);
   const [hasApprovedImage, setHasApprovedImage] = useState(false);
+  const [hasCoverImage, setHasCoverImage] = useState(false);
   const [isPublished, setIsPublished] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -84,10 +85,11 @@ export default function HostPortalPage() {
       // properties: map_url and is_published
       const { data: prop } = await supabase
         .from('properties')
-        .select('map_url,is_published')
+        .select('map_url,is_published,cover_image_url')
         .eq('id', pid)
         .maybeSingle();
       setHasMapLink(!!prop?.map_url);
+      setHasCoverImage(!!prop?.cover_image_url);
       setIsPublished(!!prop?.is_published);
       // property_images: approved exists?
       const { count } = await supabase
@@ -187,6 +189,7 @@ export default function HostPortalPage() {
                   selectedPropertyId={selectedPropertyId}
                   hasMapLink={hasMapLink}
                   hasApprovedImage={hasApprovedImage}
+                  hasCoverImage={hasCoverImage}
                   isPublished={isPublished}
                   onPublish={() => { /* TODO: wire actual publish action */ }}
                 />

--- a/components/portal/PublishChecklist.tsx
+++ b/components/portal/PublishChecklist.tsx
@@ -7,6 +7,7 @@ interface PublishChecklistProps {
   selectedPropertyId: string | null;
   hasMapLink: boolean;
   hasApprovedImage: boolean;
+  hasCoverImage: boolean;
   isPublished: boolean;
   onPublish?: () => void;
 }
@@ -15,22 +16,24 @@ export default function PublishChecklist({
   selectedPropertyId,
   hasMapLink,
   hasApprovedImage,
+  hasCoverImage,
   isPublished,
   onPublish,
 }: PublishChecklistProps) {
-  const items = [
+  // Prerequisites to publish (4 steps)
+  const prereqs = [
     { label: "Select or create a property", done: !!selectedPropertyId },
     { label: "Save a valid Google Maps link", done: hasMapLink },
     { label: "Approve at least one photo", done: hasApprovedImage },
-    { label: "Then publish from the Location card", done: isPublished },
+    { label: "Set a cover image (used on homepage & hero)", done: hasCoverImage },
   ];
-  const complete = items.filter((i) => i.done).length;
-  const readyToPublish = complete >= 3 && !isPublished; // prerequisites complete
+  const complete = prereqs.filter((i) => i.done).length;
+  const readyToPublish = complete === 4 && !isPublished;
 
   return (
     <Card title="Publish status" right={<Badge tone={complete === 4 ? "success" : "muted"}>{complete}/4 complete</Badge>}>
       <ul className="space-y-3">
-        {items.map((it, i) => (
+        {prereqs.map((it, i) => (
           <li key={i} className="flex items-start gap-3">
             <span
               className={`mt-0.5 inline-flex w-5 h-5 items-center justify-center rounded-full border ${


### PR DESCRIPTION
- PublishChecklist: require cover image before enabling Publish.\n- Host portal: compute hasCoverImage from properties.cover_image_url and pass to checklist.\n- MediaManager: show "Cover" badge; disable "Set cover" when already cover.\n\nThis PR follows #28 and contains commit dc05141.