### PR TITLE
Host portal: global search stubs for Payments and Tenants

### DIFF
--- a/app/portal/host/page.tsx
+++ b/app/portal/host/page.tsx
@@ -14,6 +14,8 @@ import Card from "@/components/portal/Card";
 import Icon from "@/components/portal/Icon";
 import SidebarItem from "@/components/portal/SidebarItem";
 import BottomBar from "@/components/portal/BottomBar";
+import PaymentsList from "@/components/portal/PaymentsList";
+import TenantsList from "@/components/portal/TenantsList";
 
 export default function HostPortalPage() {
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null);
@@ -201,6 +203,18 @@ export default function HostPortalPage() {
               <Card title="Property feedback & updates">
                 <SectionFeedback sections={sections} />
               </Card>
+            </section>
+
+            {/* Operations: Payments & Tenants (search-aware stubs) */}
+            <section>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <Card title="Payments">
+                  <PaymentsList query={searchQuery} />
+                </Card>
+                <Card title="Tenants">
+                  <TenantsList query={searchQuery} />
+                </Card>
+              </div>
             </section>
 
             {/* Bottom bar metrics */}

--- a/components/portal/PaymentsList.tsx
+++ b/components/portal/PaymentsList.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMemo } from "react";
+
+interface PaymentsListProps {
+  query?: string;
+}
+
+interface PaymentRow {
+  id: string;
+  tenant: string;
+  amount: number;
+  status: "paid" | "due" | "overdue";
+  date: string; // ISO or display
+}
+
+const MOCK_PAYMENTS: PaymentRow[] = [
+  { id: "pmt_001", tenant: "Dr. Angelica Celestine", amount: 2200, status: "paid", date: "2025-08-01" },
+  { id: "pmt_002", tenant: "Erica Rogers NP", amount: 2100, status: "due", date: "2025-08-10" },
+  { id: "pmt_003", tenant: "Marley Aguillard", amount: 2150, status: "overdue", date: "2025-07-28" },
+];
+
+export default function PaymentsList({ query }: PaymentsListProps) {
+  const q = (query ?? "").trim().toLowerCase();
+  const rows = useMemo(() => {
+    if (!q) return MOCK_PAYMENTS;
+    return MOCK_PAYMENTS.filter((r) =>
+      r.tenant.toLowerCase().includes(q) ||
+      r.status.toLowerCase().includes(q) ||
+      r.id.toLowerCase().includes(q)
+    );
+  }, [q]);
+
+  return (
+    <div className="space-y-2">
+      {rows.length === 0 && (
+        <div className="text-sm text-gray-500">No payments match "{query}".</div>
+      )}
+      {rows.map((p) => (
+        <div key={p.id} className="flex items-center justify-between rounded-lg border border-gray-200 p-3 bg-white">
+          <div className="flex items-center gap-3">
+            <div className="text-sm font-medium text-gray-900">{p.tenant}</div>
+            <div className="text-xs text-gray-500">{p.date}</div>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="text-sm text-gray-900">${p.amount.toLocaleString()}</div>
+            <span className={`px-2 py-0.5 rounded-full text-xs ${
+              p.status === "paid" ? "bg-emerald-100 text-emerald-700" : p.status === "due" ? "bg-amber-100 text-amber-700" : "bg-rose-100 text-rose-700"
+            }`}>{p.status}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/portal/TenantsList.tsx
+++ b/components/portal/TenantsList.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useMemo } from "react";
+
+interface TenantsListProps {
+  query?: string;
+}
+
+interface TenantRow {
+  id: string;
+  name: string;
+  property: string;
+  status: "active" | "past" | "pending";
+}
+
+const MOCK_TENANTS: TenantRow[] = [
+  { id: "tnt_001", name: "Dr. Nia Jenkins", property: "Lexington Night House", status: "active" },
+  { id: "tnt_002", name: "Samuel Carter", property: "Downtown Med Loft", status: "pending" },
+  { id: "tnt_003", name: "Elena Diaz", property: "Lakeview Bungalow", status: "past" },
+];
+
+export default function TenantsList({ query }: TenantsListProps) {
+  const q = (query ?? "").trim().toLowerCase();
+  const rows = useMemo(() => {
+    if (!q) return MOCK_TENANTS;
+    return MOCK_TENANTS.filter((r) =>
+      r.name.toLowerCase().includes(q) ||
+      r.property.toLowerCase().includes(q) ||
+      r.status.toLowerCase().includes(q) ||
+      r.id.toLowerCase().includes(q)
+    );
+  }, [q]);
+
+  return (
+    <div className="space-y-2">
+      {rows.length === 0 && (
+        <div className="text-sm text-gray-500">No tenants match "{query}".</div>
+      )}
+      {rows.map((t) => (
+        <div key={t.id} className="flex items-center justify-between rounded-lg border border-gray-200 p-3 bg-white">
+          <div className="flex flex-col">
+            <div className="text-sm font-medium text-gray-900">{t.name}</div>
+            <div className="text-xs text-gray-500">{t.property}</div>
+          </div>
+          <span className={`px-2 py-0.5 rounded-full text-xs ${
+            t.status === "active" ? "bg-emerald-100 text-emerald-700" : t.status === "pending" ? "bg-amber-100 text-amber-700" : "bg-gray-100 text-gray-600"
+          }`}>{t.status}</span>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add PaymentsList and TenantsList stub components that accept a query and filter mock rows.\n- Wire them into app/portal/host/page.tsx and pass sticky header searchQuery.\n- Pure UI/UX scaffolding; ready to swap to Supabase when tables exist.\n\nThis PR is atomic and follows #29.