### PR TITLE
Host portal: stabilize Create Property modal + selection callback

### DIFF
--- a/app/portal/host/page.tsx
+++ b/app/portal/host/page.tsx
@@ -237,7 +237,7 @@ export default function HostPortalPage() {
         {/* Create Property modal */}
         {showCreateModal && (
           <div className="fixed inset-0 z-40 flex items-center justify-center">
-            <div className="absolute inset-0 bg-black/30" onClick={() => setShowCreateModal(false)} />
+            <div className="absolute inset-0 bg-black/30" aria-hidden="true" />
             <div className="relative z-10 w-full max-w-2xl mx-auto">
               <Card title="Create Property" right={
                 <button onClick={() => setShowCreateModal(false)} className="text-sm text-gray-600 hover:text-gray-900">Close</button>

--- a/components/portal/PropertyForm.tsx
+++ b/components/portal/PropertyForm.tsx
@@ -57,7 +57,7 @@ export default function PropertyForm({ onPropertySelected }: PropertyFormProps) 
   }, []);
 
   useEffect(() => {
-    onPropertySelected?.(selectedId);
+    if (selectedId) onPropertySelected?.(selectedId);
   }, [selectedId, onPropertySelected]);
 
   // Fetch approved images when a property is selected to power previews/cover selection


### PR DESCRIPTION
- PropertyForm: only call onPropertySelected when a property ID exists to avoid closing modal on mount.\n- Host Portal: disable backdrop click-to-close for Create Property modal to prevent accidental dismissal.\n\nFixes flicker/auto-close on Add new Property.