### PR TITLE
Show two property cards in Media Manager grid

### DIFF
--- a/app/(host)/dashboard/_components/MediaManagerCard.tsx
+++ b/app/(host)/dashboard/_components/MediaManagerCard.tsx
@@ -12,7 +12,7 @@ import useSupabaseRealtime from "@/hooks/useSupabaseRealtime";
 import ConfirmDialog from "./ConfirmDialog";
 import PropertyCard, { PropertyCardSkeleton } from "./PropertyCard";
 
-const PAGE_SIZE = 2;
+const PAGE_SIZE = 12;
 
 export default function MediaManagerCard() {
   const router = useRouter();
@@ -164,7 +164,7 @@ export default function MediaManagerCard() {
       </div>
 
       {loading ? (
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: PAGE_SIZE }).map((_, i) => (
             <PropertyCardSkeleton key={i} />
           ))}
@@ -174,7 +174,7 @@ export default function MediaManagerCard() {
           No properties yet. Use ‘Add new property’ above.
         </p>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {properties.map((p) => (
             <PropertyCard
               key={p.id}

--- a/app/(host)/dashboard/_components/MediaManagerCard.tsx
+++ b/app/(host)/dashboard/_components/MediaManagerCard.tsx
@@ -12,7 +12,7 @@ import useSupabaseRealtime from "@/hooks/useSupabaseRealtime";
 import ConfirmDialog from "./ConfirmDialog";
 import PropertyCard, { PropertyCardSkeleton } from "./PropertyCard";
 
-const PAGE_SIZE = 16;
+const PAGE_SIZE = 12;
 
 export default function MediaManagerCard() {
   const router = useRouter();
@@ -164,7 +164,7 @@ export default function MediaManagerCard() {
       </div>
 
       {loading ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: PAGE_SIZE }).map((_, i) => (
             <PropertyCardSkeleton key={i} />
           ))}
@@ -174,7 +174,7 @@ export default function MediaManagerCard() {
           No properties yet. Use ‘Add new property’ above.
         </p>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {properties.map((p) => (
             <PropertyCard
               key={p.id}

--- a/app/(host)/dashboard/_components/MediaManagerCard.tsx
+++ b/app/(host)/dashboard/_components/MediaManagerCard.tsx
@@ -10,28 +10,9 @@ import {
 } from "@/lib/properties";
 import useSupabaseRealtime from "@/hooks/useSupabaseRealtime";
 import ConfirmDialog from "./ConfirmDialog";
+import PropertyCard, { PropertyCardSkeleton } from "./PropertyCard";
 
-function relativeTime(dateStr: string) {
-  const diff = (Date.now() - new Date(dateStr).getTime()) / 1000;
-  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-  const divisions: Array<[number, Intl.RelativeTimeFormatUnit]> = [
-    [60, "second"],
-    [60, "minute"],
-    [24, "hour"],
-    [7, "day"],
-    [4.34524, "week"],
-    [12, "month"],
-    [Infinity, "year"],
-  ];
-  let unit: Intl.RelativeTimeFormatUnit = "second";
-  let duration = diff;
-  for (const [amount, nextUnit] of divisions) {
-    if (Math.abs(duration) < amount) break;
-    duration /= amount;
-    unit = nextUnit;
-  }
-  return rtf.format(-Math.round(duration), unit);
-}
+const PAGE_SIZE = 2;
 
 export default function MediaManagerCard() {
   const router = useRouter();
@@ -65,8 +46,8 @@ export default function MediaManagerCard() {
     if (!userId) return;
     const { data, count } = await fetchProperties(supabase, userId, {
       search,
-      is_published: status === "all" ? undefined : status === "published",
-      limit: 10,
+      status: status === "all" ? undefined : status,
+      limit: PAGE_SIZE,
       offset: 0,
     });
     setProperties(data);
@@ -77,16 +58,16 @@ export default function MediaManagerCard() {
 
   const loadMore = useCallback(async () => {
     if (!userId) return;
-    const offset = page * 10;
+    const offset = page * PAGE_SIZE;
     const { data } = await fetchProperties(supabase, userId, {
       search,
-      is_published: status === "all" ? undefined : status === "published",
-      limit: 10,
+      status: status === "all" ? undefined : status,
+      limit: PAGE_SIZE,
       offset,
     });
     setProperties((prev) => [...prev, ...data]);
     setPage(page + 1);
-    if (data.length < 10) setHasMore(false);
+    if (data.length < PAGE_SIZE) setHasMore(false);
   }, [userId, supabase, search, status, page]);
 
   useEffect(() => {
@@ -111,9 +92,24 @@ export default function MediaManagerCard() {
     }
   };
 
+  const handlePublish = async (id: string) => {
+    const prev = properties;
+    setProperties(prev.map((p) => (p.id === id ? { ...p, status: "published" } : p)));
+    try {
+      await supabase.from("properties").update({ status: "published" }).eq("id", id);
+      alert("Property published");
+    } catch (err: any) {
+      setProperties(prev);
+      alert(err.message || "Failed to publish property");
+    }
+  };
+
   const matches = useCallback(
     (p: PropertyRow) => {
-      if (status !== "all" && p.is_published !== (status === "published")) return false;
+      if (status !== "all") {
+        if (status === "published" && p.status !== "published") return false;
+        if (status === "unpublished" && p.status === "published") return false;
+      }
       if (search && !p.title.toLowerCase().includes(search.toLowerCase())) return false;
       return true;
     },
@@ -168,72 +164,27 @@ export default function MediaManagerCard() {
       </div>
 
       {loading ? (
-        <ul className="divide-y divide-gray-100">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <li key={i} className="flex items-center gap-4 py-3 animate-pulse">
-              <div className="h-16 w-16 rounded-md bg-gray-200" />
-              <div className="flex-1 space-y-2">
-                <div className="h-4 w-1/3 rounded bg-gray-200" />
-                <div className="h-3 w-1/4 rounded bg-gray-200" />
-              </div>
-            </li>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+            <PropertyCardSkeleton key={i} />
           ))}
-        </ul>
+        </div>
       ) : properties.length === 0 ? (
         <p className="text-sm text-gray-500">
           No properties yet. Use ‘Add new property’ above.
         </p>
       ) : (
-        <ul className="divide-y divide-gray-100">
+        <div className="grid gap-4 sm:grid-cols-2">
           {properties.map((p) => (
-            <li key={p.id} className="flex items-center gap-4 py-3">
-              <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded-md bg-gray-100">
-                {p.cover_image_url ? (
-                  <img
-                    src={p.cover_image_url}
-                    alt={p.title}
-                    className="h-full w-full object-cover"
-                  />
-                ) : (
-                  <div className="flex h-full w-full items-center justify-center text-xs text-gray-400">
-                    No image
-                  </div>
-                )}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <p className="truncate text-sm font-medium">{p.title}</p>
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs capitalize ${
-                      p.is_published
-                        ? "bg-emerald-100 text-emerald-700"
-                        : "bg-gray-100 text-gray-600"
-                    }`}
-                  >
-                    {p.is_published ? "published" : "unpublished"}
-                  </span>
-                </div>
-                <p className="mt-1 text-xs text-gray-500">
-                  Updated {relativeTime(p.updated_at)}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => router.push(`/host/properties/${p.id}/edit`)}
-                  className="text-sm text-blue-600 hover:underline"
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => setConfirmId(p.id)}
-                  className="text-sm text-red-600 hover:underline"
-                >
-                  Delete
-                </button>
-              </div>
-            </li>
+            <PropertyCard
+              key={p.id}
+              item={p}
+              onEdit={(id) => router.push(`/host/properties/${id}/edit`)}
+              onDelete={(id) => setConfirmId(id)}
+              onPublish={handlePublish}
+            />
           ))}
-        </ul>
+        </div>
       )}
 
       {hasMore && !loading && (

--- a/app/(host)/dashboard/_components/MediaManagerCard.tsx
+++ b/app/(host)/dashboard/_components/MediaManagerCard.tsx
@@ -12,7 +12,7 @@ import useSupabaseRealtime from "@/hooks/useSupabaseRealtime";
 import ConfirmDialog from "./ConfirmDialog";
 import PropertyCard, { PropertyCardSkeleton } from "./PropertyCard";
 
-const PAGE_SIZE = 12;
+const PAGE_SIZE = 16;
 
 export default function MediaManagerCard() {
   const router = useRouter();
@@ -164,7 +164,7 @@ export default function MediaManagerCard() {
       </div>
 
       {loading ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {Array.from({ length: PAGE_SIZE }).map((_, i) => (
             <PropertyCardSkeleton key={i} />
           ))}
@@ -174,7 +174,7 @@ export default function MediaManagerCard() {
           No properties yet. Use ‘Add new property’ above.
         </p>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {properties.map((p) => (
             <PropertyCard
               key={p.id}

--- a/app/(host)/dashboard/_components/PropertyCard.tsx
+++ b/app/(host)/dashboard/_components/PropertyCard.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Pencil, Trash2, Upload } from "lucide-react";
+import { PropertyRow } from "@/lib/properties";
+
+interface PropertyCardProps {
+  item: PropertyRow;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  onPublish: (id: string) => void;
+}
+
+function relativeTime(dateStr: string) {
+  const diff = (Date.now() - new Date(dateStr).getTime()) / 1000;
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  const divisions: Array<[number, Intl.RelativeTimeFormatUnit]> = [
+    [60, "second"],
+    [60, "minute"],
+    [24, "hour"],
+    [7, "day"],
+    [4.34524, "week"],
+    [12, "month"],
+    [Infinity, "year"],
+  ];
+  let unit: Intl.RelativeTimeFormatUnit = "second";
+  let duration = diff;
+  for (const [amount, nextUnit] of divisions) {
+    if (Math.abs(duration) < amount) break;
+    duration /= amount;
+    unit = nextUnit;
+  }
+  return rtf.format(-Math.round(duration), unit);
+}
+
+const statusClasses: Record<PropertyRow["status"], string> = {
+  draft: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  published: "bg-green-50 text-green-700 border-green-200",
+  archived: "bg-gray-50 text-gray-600 border-gray-200",
+};
+
+export default function PropertyCard({ item, onEdit, onDelete, onPublish }: PropertyCardProps) {
+  return (
+    <div
+      tabIndex={0}
+      className="rounded-2xl border bg-white shadow-sm p-4 hover:shadow-md transition focus:outline-none focus:ring-2 focus:ring-black/10"
+    >
+      <div className="mb-4 h-36 w-full overflow-hidden rounded-xl bg-gray-100 flex items-center justify-center">
+        {item.cover_image_url ? (
+          <img
+            src={item.cover_image_url}
+            alt={item.title}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="h-8 w-8 text-gray-400"
+          >
+            <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+            <circle cx="8.5" cy="8.5" r="1.5" />
+            <path d="M21 15l-5-5L5 21" />
+          </svg>
+        )}
+      </div>
+      <h4 className="mb-1 truncate text-sm font-bold" title={item.title}>
+        {item.title}
+      </h4>
+      <p
+        className="text-sm text-gray-600"
+        style={{
+          display: "-webkit-box",
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+        }}
+      >
+        {item.description || "No description yet."}
+      </p>
+      <div className="mt-4 flex items-center justify-between text-xs">
+        <span
+          className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full border ${statusClasses[item.status]}`}
+        >
+          {item.status}
+        </span>
+        <span className="text-gray-500">Updated {relativeTime(item.updated_at)}</span>
+      </div>
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
+        <button
+          aria-label="Edit property"
+          onClick={() => onEdit(item.id)}
+          className="inline-flex items-center justify-center rounded-xl px-3 py-1.5 text-sm font-medium border border-gray-300 text-gray-800 hover:bg-gray-50"
+        >
+          <Pencil className="mr-1 h-4 w-4" /> Edit
+        </button>
+        <button
+          aria-label="Delete property"
+          onClick={() => onDelete(item.id)}
+          className="inline-flex items-center justify-center rounded-xl px-3 py-1.5 text-sm font-medium border border-red-300 text-red-700 hover:bg-red-50"
+        >
+          <Trash2 className="mr-1 h-4 w-4" /> Delete
+        </button>
+        <button
+          aria-label="Publish property"
+          disabled={item.status === 'published'}
+          onClick={() => onPublish(item.id)}
+          className="inline-flex items-center justify-center rounded-xl px-3 py-1.5 text-sm font-medium bg-black text-white hover:bg-gray-900 disabled:opacity-50"
+        >
+          <Upload className="mr-1 h-4 w-4" /> Publish
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function PropertyCardSkeleton() {
+  return (
+    <div className="rounded-2xl border bg-white shadow-sm p-4">
+      <div className="mb-4 h-36 w-full rounded-xl bg-gray-100 animate-pulse" />
+      <div className="mb-2 h-4 w-3/4 rounded bg-gray-100 animate-pulse" />
+      <div className="mb-1 h-3 w-full rounded bg-gray-100 animate-pulse" />
+      <div className="mb-4 h-3 w-2/3 rounded bg-gray-100 animate-pulse" />
+      <div className="h-4 w-1/3 rounded bg-gray-100 animate-pulse" />
+    </div>
+  );
+}

--- a/lib/properties.ts
+++ b/lib/properties.ts
@@ -216,7 +216,7 @@ interface FetchOptions {
 export async function fetchProperties(
   client: SupabaseClient,
   ownerId: string,
-  { search, status, limit = 12, offset = 0 }: FetchOptions = {},
+  { search, status, limit = 16, offset = 0 }: FetchOptions = {},
 ): Promise<{ data: PropertyRow[]; count: number }>
 {
   const from = offset

--- a/lib/properties.ts
+++ b/lib/properties.ts
@@ -216,7 +216,7 @@ interface FetchOptions {
 export async function fetchProperties(
   client: SupabaseClient,
   ownerId: string,
-  { search, status, limit = 16, offset = 0 }: FetchOptions = {},
+  { search, status, limit = 12, offset = 0 }: FetchOptions = {},
 ): Promise<{ data: PropertyRow[]; count: number }>
 {
   const from = offset


### PR DESCRIPTION
## Summary
- Limit Media Manager to two property cards per page
- Display cards in a two-column grid for more spacious layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_689b9bb2bde08324b10598c0c0b6be98