### PR TITLE
Add account settings and sign-out menu for host portal

### DIFF
--- a/app/portal/host/account/page.tsx
+++ b/app/portal/host/account/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import AuthGate from "@/components/portal/AuthGate";
 import UserMenu from "@/components/portal/UserMenu";
 import { createClient } from "@/lib/supabase/client";
 
 export default function HostAccountPage() {
   const supabase = createClient();
+  const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [firstName, setFirstName] = useState("");
   const [avatarUrl, setAvatarUrl] = useState("");
@@ -75,7 +78,12 @@ export default function HostAccountPage() {
     const { error } = await supabase
       .from("user_profiles")
       .upsert({ id: user.id, first_name: firstName, avatar_url: avatarUrl, preferences: prefs });
-    if (error) alert(error.message); else alert("Profile updated");
+    if (error) {
+      alert(error.message);
+    } else {
+      alert("Profile updated");
+      router.push("/portal/host");
+    }
   };
 
   return (
@@ -83,7 +91,12 @@ export default function HostAccountPage() {
       <div className="min-h-screen bg-gray-50">
         <header className="sticky top-0 z-30 bg-white border-b border-gray-100">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
-            <h1 className="text-lg font-semibold">Account</h1>
+            <div className="flex items-center gap-4">
+              <Link href="/portal/host" className="text-blue-600 hover:underline flex items-center">
+                <span className="mr-1">&larr;</span> Back
+              </Link>
+              <h1 className="text-lg font-semibold">Account</h1>
+            </div>
             <UserMenu />
           </div>
         </header>

--- a/components/portal/UserMenu.tsx
+++ b/components/portal/UserMenu.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 
 export default function UserMenu() {
   const supabase = createClient();
+  const router = useRouter();
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [firstName, setFirstName] = useState<string>("");
   const [avatarUrl, setAvatarUrl] = useState<string>("");
@@ -31,7 +34,7 @@ export default function UserMenu() {
     try {
       localStorage.removeItem("mr_session");
     } catch {}
-    window.location.href = "/";
+    router.push("/");
   };
 
   return (
@@ -54,8 +57,14 @@ export default function UserMenu() {
             {firstName || "Account"}
           </div>
           <a
+            href="/portal/host"
+            className={`block px-4 py-2 text-sm hover:bg-gray-50 ${pathname === "/portal/host" ? "bg-blue-50 text-gray-900" : "text-gray-700"}`}
+          >
+            Account
+          </a>
+          <a
             href="/portal/host/account"
-            className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
+            className={`block px-4 py-2 text-sm hover:bg-gray-50 ${pathname === "/portal/host/account" ? "bg-blue-50 text-gray-900" : "text-gray-700"}`}
           >
             Account settings
           </a>


### PR DESCRIPTION
## Summary
- Add back navigation and redirect after profile save
- Enhance host user menu with router-aware links and sign-out handling

## Testing
- `npm run lint` *(fails: asks for ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bc18e9c988324bab17b9838e8058a