### PR TITLE
refactor: reorder favicon metadata and add theme color

### DIFF
--- a/app/head.tsx
+++ b/app/head.tsx
@@ -4,6 +4,8 @@ export default function Head() {
       <meta name="msapplication-TileColor" content="#0A0A0A" />
       <meta name="msapplication-config" content="/my-favicon/browserconfig.xml" />
       <link rel="mask-icon" href="/my-favicon/safari-pinned-tab.svg" color="#0A0A0A" />
+      {/* Optional but nice for Android address bar */}
+      <meta name="theme-color" content="#000000" />
     </>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,19 +11,16 @@ export const metadata: Metadata = {
   // metadataBase: new URL('https://www.bellerouges.com'),
   manifest: '/my-favicon/site.webmanifest',
   icons: {
-    // Prefer tiny sizes first for best tab legibility
+    // Put tiny sizes first for best tab legibility
     icon: [
       { url: '/my-favicon/favicon-16x16.png?v=2', sizes: '16x16', type: 'image/png' },
       { url: '/my-favicon/favicon-32x32.png?v=2', sizes: '32x32', type: 'image/png' },
-      { url: '/my-favicon/favicon.ico' },
       { url: '/my-favicon/favicon.svg', type: 'image/svg+xml' },
+      { url: '/my-favicon/favicon.ico' }, // keep one .ico ref only
     ],
-    apple: [
-      { url: '/my-favicon/apple-touch-icon.png', sizes: '180x180' },
-    ],
+    apple: [{ url: '/my-favicon/apple-touch-icon.png', sizes: '180x180' }],
     shortcut: ['/my-favicon/favicon.ico'],
   },
-  // msapplication tags are better placed in <head>, but we can keep other meta here if needed later
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- reorder favicon metadata in layout and dedupe .ico reference
- add platform-specific meta tags to head including theme-color

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689feaadfa2c832497fae88983b43d18